### PR TITLE
Add support for Cap 3.7 and rvm/bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Configurable options, shown here with defaults:
 
 ```ruby
 set :foreman_systemd_roles, :all
-set :foreman_systemd_export_format, 'upstart'
+set :foreman_systemd_export_format, 'systemd'
 set :foreman_systemd_export_path, '/etc/init'
 set :foreman_systemd_flags, "--root=#{current_path}" # optional, default is empty string
 set :foreman_systemd_target_path, release_path

--- a/capistrano-foreman-systemd.gemspec
+++ b/capistrano-foreman-systemd.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'capistrano', '~> 3.4.1'
+  spec.add_dependency 'capistrano', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/capistrano/tasks/foreman_systemd.rake
+++ b/lib/capistrano/tasks/foreman_systemd.rake
@@ -25,14 +25,18 @@ namespace :foreman_systemd do
   desc 'Enables service in systemd'
   task :enable do
     on roles fetch(:foreman_systemd_roles) do
-      sudo :systemctl, "enable #{fetch(:foreman_systemd_app)}.target"
+      as "root" do
+        execute :systemctl, "enable #{fetch(:foreman_systemd_app)}.target"
+      end
     end
   end
 
   desc 'Disables service in systemd'
   task :disable do
     on roles fetch(:foreman_systemd_roles) do
-      sudo :systemctl, "disable #{fetch(:foreman_systemd_app)}.target"
+      as "root" do
+        execute :systemctl, "disable #{fetch(:foreman_systemd_app)}.target"
+      end
     end
   end
 
@@ -52,8 +56,10 @@ namespace :foreman_systemd do
         options[:port] = fetch(:foreman_systemd_port) if fetch(:foreman_systemd_port)
         options[:user] = fetch(:foreman_systemd_user) if fetch(:foreman_systemd_user)
 
-        sudo :foreman, 'export', fetch(:foreman_systemd_export_format), fetch(:foreman_systemd_export_path),
-          options.map{ |k, v| "--#{k}='#{v}'" }, fetch(:foreman_systemd_flags)
+        as "root" do
+          execute :foreman, 'export', fetch(:foreman_systemd_export_format), fetch(:foreman_systemd_export_path),
+            options.map{ |k, v| "--#{k}='#{v}'" }, fetch(:foreman_systemd_flags)
+        end
       end
     end
   end
@@ -61,21 +67,27 @@ namespace :foreman_systemd do
   desc 'Start the application services'
   task :start do
     on roles fetch(:foreman_systemd_roles) do
-      sudo :systemctl, "start #{fetch(:foreman_systemd_app)}.target"
+      as "root" do
+        execute :systemctl, "start #{fetch(:foreman_systemd_app)}.target"
+      end
     end
   end
 
   desc 'Stop the application services'
   task :stop do
     on roles fetch(:foreman_systemd_roles) do
-      sudo :systemctl, "stop #{fetch(:foreman_systemd_app)}.target"
+      as "root" do
+        execute :systemctl, "stop #{fetch(:foreman_systemd_app)}.target"
+      end
     end
   end
 
   desc 'Restart the application services'
   task :restart do
     on roles fetch(:foreman_systemd_roles) do
-      sudo :systemctl, "restart #{fetch(:foreman_systemd_app)}.target"
+      as "root" do
+        execute :systemctl, "restart #{fetch(:foreman_systemd_app)}.target"
+      end
     end
   end
 

--- a/lib/capistrano/tasks/foreman_systemd.rake
+++ b/lib/capistrano/tasks/foreman_systemd.rake
@@ -18,6 +18,13 @@ namespace :foreman_systemd do
 
   task :setup do
     invoke :'foreman_systemd:export'
+
+    on roles fetch(:foreman_systemd_roles) do
+      as "root" do
+        execute :systemctl, "daemon-reload"
+      end
+    end
+
     invoke :'foreman_systemd:enable'
     invoke :'foreman_systemd:start'
   end

--- a/lib/capistrano/tasks/foreman_systemd.rake
+++ b/lib/capistrano/tasks/foreman_systemd.rake
@@ -5,7 +5,7 @@ namespace :foreman_systemd do
         Configurable options are:
 
           set :foreman_systemd_roles, :all
-          set :foreman_systemd_export_format, 'upstart'
+          set :foreman_systemd_export_format, 'systemd'
           set :foreman_systemd_export_path, '/etc/init'
           set :foreman_systemd_flags, ''
           set :foreman_systemd_target_path, release_path


### PR DESCRIPTION
The gem works fine for me with Capistrano 3.7. Also fixed the gem's behavior when used alongside things like rvm and bundler.

refs #1 