### PR TITLE
Relax capistrano restriction

### DIFF
--- a/capistrano-foreman-systemd.gemspec
+++ b/capistrano-foreman-systemd.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'capistrano', '~> 3.4.1'
+  spec.add_dependency 'capistrano', '~> 3.4'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
I'd like to use this for Capistrano 3.7, but it's currently locked to 3.4.